### PR TITLE
统一项目名并增加自动化构建工作流

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,67 @@
+name: 🚀 Build CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build-matrix:
+    name: 🔨 Build ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            platform: windows
+          - os: ubuntu-latest
+            platform: linux
+          - os: macos-latest
+            platform: macos
+
+    env:
+      PYTHONIOENCODING: utf-8
+      ASSET_NAME: nano-banana-prompt-studio-${{ matrix.platform }}-ci.zip
+
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
+
+      - name: 🐍 Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: 'pip'
+
+      - name: 🐧 Install Linux Deps
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1 libegl1 libxkbcommon0 libdbus-1-3 libxcb-cursor0
+
+      - name: 📦 Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: 🔨 Build with PyInstaller
+        run: python build.py
+
+      - name: 📦 Pack Artifacts (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          Compress-Archive -Path output/* -DestinationPath ${{ env.ASSET_NAME }}
+
+      - name: 📦 Pack Artifacts (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          cd output
+          zip -r ../${{ env.ASSET_NAME }} *
+
+      - name: 📤 Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifact-${{ matrix.platform }}
+          path: ${{ env.ASSET_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,100 @@
+name: 🚀 Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. v1.0.0)'
+        required: true
+        default: 'v1.0.0'
+
+permissions:
+  contents: write
+
+jobs:
+  build-matrix:
+    name: 🔨 Build ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            platform: windows
+          - os: ubuntu-latest
+            platform: linux
+          - os: macos-latest
+            platform: macos
+
+    env:
+      PYTHONIOENCODING: utf-8
+      ASSET_NAME: nano-banana-prompt-studio-${{ matrix.platform }}-${{ inputs.version }}.zip
+
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
+
+      - name: 🐍 Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: 'pip'
+
+      - name: 🐧 Install Linux Deps
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1 libegl1 libxkbcommon0 libdbus-1-3 libxcb-cursor0
+
+      - name: 📦 Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: 🔨 Build with PyInstaller
+        run: python build.py
+
+      - name: 📦 Pack Artifacts (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          Compress-Archive -Path output/* -DestinationPath ${{ env.ASSET_NAME }}
+
+      - name: 📦 Pack Artifacts (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          cd output
+          zip -r ../${{ env.ASSET_NAME }} *
+
+      - name: 📤 Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifact-${{ matrix.platform }}
+          path: ${{ env.ASSET_NAME }}
+
+  create-release:
+    name: 🚀 Create Release
+    needs: build-matrix
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: releases
+
+      - name: 📦 Flatten Artifacts
+        run: |
+          find releases -mindepth 2 -type f -name "*.zip" -exec mv {} releases/ \;
+          find releases -mindepth 1 -type d -exec rm -rf {} +
+
+      - name: 🧾 Generate Checksums
+        run: |
+          cd releases
+          sha256sum *.zip > checksums.txt
+
+      - name: 🚀 Publish to GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ inputs.version }}
+          name: Release ${{ inputs.version }}
+          files: releases/*
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 
 ### 下载客户端使用
 
-在[Releases](https://github.com/lissettecarlr/nano-banana-prompt-tool/releases)页面下载最新客户端，目前只编译了`windows`版本，解压后双击运行。
+在[Releases](https://github.com/lissettecarlr/nano-banana-prompt-studio/releases)页面下载最新客户端，目前只编译了`windows`版本，解压后双击运行。
 
 
 ### 通过代码运行
@@ -58,8 +58,8 @@
 
 ```bash
 # 克隆仓库
-git clone https://github.com/your-username/nano_banana_prompt_tool.git
-cd nano_banana_prompt_tool
+git clone https://github.com/your-username/nano-banana-prompt-studio.git
+cd nano-banana-prompt-studio
 
 # 安装依赖
 pip install -r requirements.txt
@@ -74,8 +74,8 @@ python main.py
 
 #### 打包
 ```bash
-python .\build.py 
-``` 
+python build.py
+```
 
 ## 使用说明
 


### PR DESCRIPTION
# 变更动机
当前项目仅支持 Windows 手动构建，且存在命名不统一（`Tool` vs `Studio`）的问题。为了提升跨平台兼容性并简化发布流程，进行了以下改进。

## 主要修改

### 1. 统一项目名称
*   将 `README.md` 和 `build.py` 中的项目标识符统一为 `nano-banana-prompt-studio`。

### 2. 修复跨平台构建 (`build.py`)
*   **路径分隔符:** 使用 `os.pathsep` 替代硬编码的 `;`，修复 Linux/macOS 下 PyInstaller 参数解析错误。
*   **macOS Bundle:** 增加了对 macOS `.app` Bundle 的识别与复制逻辑。
*   **平台隔离:** 为 Windows 特有的 DLL 清理逻辑添加了 `sys.platform == 'win32'` 保护，防止在其他平台上误删文件。

### 3. 新增 CI/CD 工作流 (`.github/workflows/`)
*   **Build CI (`build.yml`):** 推送代码时自动触发，支持 Windows/Linux/macOS 多架构并行构建。
*   **Release (`release.yml`):** 手动触发发布，自动打包、生成校验和 (`checksums.txt`) 并发布 Release。

## 验证
*   ✅ GitHub Actions 所有平台构建均已通过。
*   ✅ 产物命名格式已统一为 `nano-banana-prompt-studio-{platform}-{version}.zip`。